### PR TITLE
Corrected the spelling of 'from' in 'about.vue'

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -162,7 +162,7 @@ useHead({
           <span class="bg-primary text-primary-content px-1 rounded">
             Git, GitHub, CI/CD and writing tests using Django's inbuilt Testing
             Framework </span
-          >. Aside fron this, I'm very familiar with PaaS'
+          >. Aside from this, I'm very familiar with PaaS'
           <span class="bg-primary text-primary-content px-1 rounded">
             Railway, Heroku and Vercel</span
           >. And ofcourse I've my fair share with


### PR DESCRIPTION
There is a spelling mistake in the word "from" on the about page.

![image](https://user-images.githubusercontent.com/88075256/216944484-ef1fbee7-5642-43be-ba72-89a8eaa3d7f3.png)

Since your portfolio looks awesome so I thought that I should also contribute to this awesome project. I know it`s a very small change but for me, it is very big this because it`s my first PR.

Best of Luck with your portfolio and let me know if you need some help with building the portfolio.
❤❤❤❤